### PR TITLE
support FIPS endpoints

### DIFF
--- a/ecrhelper.go
+++ b/ecrhelper.go
@@ -15,7 +15,7 @@ import (
 	ecrapi "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 )
 
-const ECR_REPO_REGEX = `[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*`
+const ECR_REPO_REGEX = `[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr(-fips)?\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*`
 
 //go:generate counterfeiter -o fakes/fake_ecrhelper.go . ECRHelper
 type ECRHelper interface {

--- a/ecrhelper_test.go
+++ b/ecrhelper_test.go
@@ -26,6 +26,14 @@ var _ = Describe("Ecrhelper", func() {
 			})
 		})
 
+		Context("when FIPS ECR repo URL is passed in", func() {
+			It("returns true", func() {
+				isECRREpo, err := ecrHelper.IsECRRepo("555555555.dkr.ecr-fips.us-east-1.amazonaws.com/diego-docker-app")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isECRREpo).To(BeTrue())
+			})
+		})
+
 		Context("when not ECR repo URL is passed in", func() {
 			It("returns false", func() {
 				isECRRepo, err := ecrHelper.IsECRRepo("docker.io/cloudfoundry/diego-docker-app")


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

AWS makes available FIPS-140 compliant endpoints for services including ECR (https://aws.amazon.com/compliance/fips/). Currently, the ecrhelper fails when attempting to use these endpoints. 

Backward Compatibility
---------------
Breaking Change? **No**

The change is additive. Existing non-fips endpoints are valid.
